### PR TITLE
Increase max lag before disconnect

### DIFF
--- a/netflux-client.js
+++ b/netflux-client.js
@@ -25,7 +25,7 @@ var factory = function () {
     var MAX_LAG_BEFORE_PING = 15000;
 
     // How much of a lag we accept before we will drop the socket
-    var MAX_LAG_BEFORE_DISCONNECT = 30000;
+    var MAX_LAG_BEFORE_DISCONNECT = 60000;
 
     // How often to ping the server
     var PING_CYCLE = 5000;


### PR DESCRIPTION
The WebSocket connection is kept alive by sending a ping message at every 5 seconds, using ``setTimeout``. When the browser tab / window is not active those 5 second can go up to 1 minute because browsers do "timer throttling", see https://developer.chrome.com/blog/timer-throttling-in-chrome-88/ .

I propose to increase the max lag before disconnect to 1 minute to match the "timer throttling" performed by browsers. I tested it and the connection was kept alive (without any disconnect) for 30 minutes (before I closed it), while the browser tab / window was left in background.